### PR TITLE
Fix cfde-submit not properly gathering scopes in multiple places

### DIFF
--- a/cfde_submit/client.py
+++ b/cfde_submit/client.py
@@ -234,7 +234,7 @@ class CfdeClient():
         # its own authorizer to talk to the core automate service. Ideally, this would be
         # cleaner so we wouldn't have to track the tokens and authorizer separately.
         self.__flow_client = globus_automate_client.FlowsClient(
-            flows_token_map, self.client_id, "flows_client",
+            self.client_id, None,
             app_name=self.app_name,
             base_url="https://flows.automate.globus.org",
             authorizer=automate_authorizer

--- a/cfde_submit/config.py
+++ b/cfde_submit/config.py
@@ -45,7 +45,8 @@ CONFIG = {
             "cfde_submit": {"level": "DEBUG", "handlers": ["console"]},
         },
     },
-    # Automate Scopes
+    # This scope lists the GCS server for PROD that holds config data. It MAY be different
+    # from the server responsible for holding data (for instance --service-instance dev)
     "HTTPS_SCOPE": "https://auth.globus.org/scopes/0e57d793-f1ac-4eeb-a30f-643b082d68ec/https",
     "AUTOMATE_SCOPES": list(globus_automate_client.flows_client.ALL_FLOW_SCOPES),
     # Format for BDBag archives

--- a/cfde_submit/main.py
+++ b/cfde_submit/main.py
@@ -1,11 +1,12 @@
 import json
 import os
+import logging
 
 import click
 
 from cfde_submit import CfdeClient, exc
 
-
+logger = logging.getLogger(__name__)
 DEFAULT_STATE_FILE = os.path.expanduser("~/.cfde_client.json")
 
 
@@ -115,6 +116,7 @@ def run(data_path, dcc_id, catalog, schema, acl_file, output_dir, delete_dir, ig
                                            test_sub=test_submission, verbose=verbose,
                                            force_http=force_http, **bag_kwargs)
     except Exception as e:
+        logger.exception(e)
         print("Error while starting Flow: {}".format(repr(e)))
         return
     else:

--- a/cfde_submit/version.py
+++ b/cfde_submit/version.py
@@ -1,2 +1,2 @@
 # Single source of truth for package version
-__version__ = "0.1.4"
+__version__ = "0.1.5.dev0"


### PR DESCRIPTION
Previously, scopes were statically defined in self.SCOPES. This wasn't good enough, since the automate scope is dynamic based on the latest deployed scope and the service instance can differ, resulting in a different scope needed for the https server. Both caused problems in separate areas for submissions, and these changes should fix both problems, and make the login behavior much smarter for determining what scopes need to be requested.