### PR TITLE
Fix inconsistent logins

### DIFF
--- a/cfde_submit/client.py
+++ b/cfde_submit/client.py
@@ -114,6 +114,7 @@ def ts_validate(data_path, schema=None):
 class CfdeClient():
     """The CfdeClient enables easily using the CFDE tools to ingest data."""
     client_id = "417301b1-5101-456a-8a27-423e71a2ae26"
+    config_filename = os.path.expanduser("~/.cfde-submit.cfg")
     app_name = "CfdeClient"
     archive_format = "tgz"
 
@@ -134,8 +135,10 @@ class CfdeClient():
         self.__remote_config = {}  # managed by property
         self.__tokens = {}
         self.__flow_client = None
+        self.local_config = fair_research_login.ConfigParserTokenStorage(filename=self.config_filename)
         self.__native_client = fair_research_login.NativeClient(client_id=self.client_id,
-                                                                app_name=self.app_name)
+                                                                app_name=self.app_name,
+                                                                token_storage=self.local_config)
         self.last_flow_run = {}
         # Fetch dynamic config info
         self.tokens = tokens or {}

--- a/cfde_submit/client.py
+++ b/cfde_submit/client.py
@@ -118,7 +118,7 @@ class CfdeClient():
     app_name = "CfdeClient"
     archive_format = "tgz"
 
-    def __init__(self, service_instance="prod", tokens=None):
+    def __init__(self, tokens=None):
         """Create a CfdeClient.
 
         Keyword Arguments:
@@ -131,7 +131,7 @@ class CfdeClient():
                     be called instead.
                     **Default**: ``None``.
         """
-        self.service_instance = service_instance
+        self.__service_instance = os.getenv("CFDE_SUBMIT_SERVICE_INSTANCE", "prod")
         self.__remote_config = {}  # managed by property
         self.__tokens = {}
         self.__flow_client = None
@@ -167,6 +167,18 @@ class CfdeClient():
         if new_tokens and set(new_tokens) != set(self.scopes):
             raise exc.NotLoggedIn("Tokens supplied to CfdeClient are invalid, "
                                   f"They MUST match {self.scopes}")
+
+    @property
+    def service_instance(self):
+        return self.__service_instance
+
+    @service_instance.setter
+    def service_instance(self, new_service_instance):
+        valid_si = ["dev", "staging", "prod"]
+        if new_service_instance not in valid_si:
+            raise exc.CfdeClientException(f"Invalid Service Instance {new_service_instance}, "
+                                          f"must be one of {valid_si}")
+        self.__service_instance = new_service_instance
 
     def login(self, **login_kwargs):
         """Login to the cfde-submit client. This will ensure the user has the correct

--- a/cfde_submit/main.py
+++ b/cfde_submit/main.py
@@ -109,13 +109,21 @@ def run(data_path, dcc_id, catalog, schema, acl_file, output_dir, delete_dir, ig
             cfde.login()
         if verbose:
             print("CfdeClient initialized, starting Flow")
-        start_res = cfde.start_deriva_flow(data_path, dcc_id=dcc_id, catalog_id=catalog,
-                                           schema=schema, dataset_acls=dataset_acls,
-                                           output_dir=output_dir, delete_dir=delete_dir,
-                                           handle_git_repos=(not ignore_git),
-                                           server=server, dry_run=dry_run,
-                                           test_sub=test_submission, verbose=verbose,
-                                           force_http=force_http, **bag_kwargs)
+        resp = input(f"Submit datapackage {os.path.basename(data_path)} using {dcc_id}? (y/N)? > ")
+        if resp in ["y", "yes", "Y", "Yes", "aye", "yarr"]:
+            start_res = cfde.start_deriva_flow(data_path, dcc_id=dcc_id, catalog_id=catalog,
+                                               schema=schema, dataset_acls=dataset_acls,
+                                               output_dir=output_dir, delete_dir=delete_dir,
+                                               handle_git_repos=(not ignore_git),
+                                               server=server, dry_run=dry_run,
+                                               test_sub=test_submission, verbose=verbose,
+                                               force_http=force_http, **bag_kwargs)
+        else:
+            click.secho("Aborted. No data submitted.", fg="yellow")
+            return
+    except exc.SubmissionsUnavailable as su:
+        click.secho(str(su), fg='red')
+        return
     except Exception as e:
         logger.exception(e)
         print("Error while starting Flow: {}".format(repr(e)))

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -22,6 +22,15 @@ def test_scopes(mock_remote_config):
                                    f'{service}_flow_id/flow_{service}_flow_id_user')
 
 
+@pytest.mark.parametrize("config_setting", ["cfde_ep_id", "flow_id"])
+def test_submissions_disabled(mock_remote_config, config_setting):
+    cfde = client.CfdeClient()
+    cfde.service_instance = "prod"
+    mock_remote_config.return_value["FLOWS"]["prod"][config_setting] = None
+    with pytest.raises(exc.SubmissionsUnavailable):
+        cfde.check()
+
+
 def test_start_deriva_flow_while_logged_out(logged_out):
     with pytest.raises(exc.NotLoggedIn):
         client.CfdeClient().start_deriva_flow("path_to_executable.zip", "my_dcc")
@@ -30,12 +39,6 @@ def test_start_deriva_flow_while_logged_out(logged_out):
 def test_client_invalid_version(logged_in, mock_remote_config):
     mock_remote_config.return_value["MIN_VERSION"] = "9.9.9"
     with pytest.raises(exc.OutdatedVersion):
-        client.CfdeClient().check()
-
-
-def test_client_no_flow_id(logged_in, mock_remote_config):
-    mock_remote_config.return_value["FLOWS"]["prod"]["flow_id"] = ""
-    with pytest.raises(exc.SubmissionsUnavailable):
         client.CfdeClient().check()
 
 

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -1,4 +1,5 @@
 import pytest
+from globus_automate_client.flows_client import ALL_FLOW_SCOPES
 from cfde_submit import client, exc
 
 
@@ -8,6 +9,17 @@ def test_logged_out(logged_out):
 
 def test_logged_in(logged_in):
     assert client.CfdeClient().is_logged_in() is True
+
+
+def test_scopes(mock_remote_config):
+    cfde = client.CfdeClient()
+    for service in ["dev", "staging", "prod"]:
+        # Ensure all automate scopes are present
+        cfde.service_instance = service
+        assert not set(ALL_FLOW_SCOPES).difference(cfde.scopes)
+        assert f'{service}_cfde_ep_id' in cfde.gcs_https_scope
+        assert cfde.flow_scope == (f'https://auth.globus.org/scopes/'
+                                   f'{service}_flow_id/flow_{service}_flow_id_user')
 
 
 def test_start_deriva_flow_while_logged_out(logged_out):


### PR DESCRIPTION
Previously, running `cfde-submit login` and `cfde-submit run --service-instance dev mypackage.tgz` initiated different login flows, because the former would login with "prod" scopes and the latter would login with "dev" scopes. These changes remove the `--service-instance dev` flag, and instead change the setting to an env var:

    export CFDE_SUBMIT_SERVICE_INSTANCE=dev

Using env vars, it's a lot harder to run cfde-submit commands using differing environments between commands.  