### PR TITLE
Fixed '--force-http' flag getting passed to bdbag on directories

### DIFF
--- a/cfde_submit/client.py
+++ b/cfde_submit/client.py
@@ -231,7 +231,8 @@ class CfdeClient():
     def start_deriva_flow(self, data_path, dcc_id, catalog_id=None,
                           schema=None, server=None,
                           output_dir=None, delete_dir=False, handle_git_repos=True,
-                          dry_run=False, test_sub=False, verbose=False, **kwargs):
+                          dry_run=False, test_sub=False, verbose=False,
+                          force_http=False, **kwargs):
         """Start the Globus Automate Flow to ingest CFDE data into DERIVA.
 
         Arguments:
@@ -325,7 +326,6 @@ class CfdeClient():
         # Local EP fetched now in case GCP started after Client creation
         local_endpoint = globus_sdk.LocalGlobusConnectPersonal().endpoint_id
         logger.debug(f'Local endpoint: {local_endpoint}')
-        force_http = kwargs.pop("force_http", False)
         if local_endpoint and not force_http:
             logger.debug("Using local Globus Connect Personal Endpoint '{}'".format(local_endpoint))
             # Populate Transfer fields in Flow

--- a/tests/unit/test_client.py
+++ b/tests/unit/test_client.py
@@ -87,6 +87,16 @@ def test_start_deriva_flow_gcp(logged_in, mock_validation, mock_remote_config, m
     }
 
 
+def test_start_deriva_flow_force_http(logged_in, mock_validation, mock_remote_config,
+                                      mock_flows_client, mock_upload, mock_gcp_installed):
+    mock_validation.return_value = "/home/cfde-user/bagged_path.zip"
+    client.CfdeClient().start_deriva_flow("bagged_path.zip", "my_dcc", force_http=True)
+    assert mock_validation.called
+    assert mock_upload.called
+    assert mock_flows_client.get_flow.called
+    assert mock_flows_client.run_flow.called
+
+
 def test_client_invalid_version(logged_in, mock_remote_config):
     mock_remote_config.return_value["MIN_VERSION"] = "9.9.9"
     with pytest.raises(exc.OutdatedVersion):


### PR DESCRIPTION
When running directories, bdbag would end up receiving flags it
shouldn't, resulting in errors when it tried to package directories
into bdbags