### PR TITLE
Added more robust CLI auth behavior, added CLI tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 build/
 dist/
 
+.coverage
 *.egg-info*
 *.log
 *.pyc

--- a/cfde_submit/client.py
+++ b/cfde_submit/client.py
@@ -94,7 +94,10 @@ class CfdeClient():
         logger.info("Initiating Native App Login...")
         logger.debug(f"Requesting Scopes: {self.scopes}")
         login_kwargs["requested_scopes"] = login_kwargs.get("requested_scopes", self.scopes)
-        self.__native_client.login(**login_kwargs)
+        try:
+            self.__native_client.login(**login_kwargs)
+        except fair_research_login.LoginException as le:
+            raise exc.NotLoggedIn(f"Unable to login: {str(le)}") from le
 
     def logout(self):
         """Log out and revoke this client's tokens. This object will no longer

--- a/cfde_submit/main.py
+++ b/cfde_submit/main.py
@@ -209,8 +209,8 @@ def login(force_login, no_browser, no_local_server):
     """Perform the login step (which saves credentials) by initializing
     a CfdeClient. The Client is then discarded.
     """
-    logged_in = CfdeClient().is_logged_in()
-    if logged_in:
+    logger.debug(f'Logged in? {CfdeClient().is_logged_in()}')
+    if CfdeClient().is_logged_in():
         click.secho("You are already logged in")
     else:
         login_user(force_login, no_browser, no_local_server)

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,1 +1,2 @@
 pytest
+pytest-cov

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,10 @@
+from click.testing import CliRunner
+from cfde_submit.main import cli
+from cfde_submit.version import __version__
+
+
+def test_version():
+    runner = CliRunner()
+    result = runner.invoke(cli, ['version'])
+    assert result.exit_code == 0
+    assert __version__ in result.output

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -10,11 +10,11 @@ def test_login(mock_login, logged_out):
     assert mock_login.login.called
 
 
-def test_login_when_logged_in(mock_login, logged_out):
+def test_login_when_logged_in(mock_login, logged_in):
     runner = CliRunner()
     result = runner.invoke(cli, ['login'])
     assert result.exit_code == 0
-    assert mock_login.login.called
+    assert not mock_login.login.called
 
 
 def test_logout(mock_login, logged_in):
@@ -22,6 +22,13 @@ def test_logout(mock_login, logged_in):
     result = runner.invoke(cli, ['logout'])
     assert result.exit_code == 0
     assert mock_login.logout.called
+
+
+def test_logout_when_logged_out(mock_login, logged_out):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['logout'])
+    assert result.exit_code == 0
+    assert not mock_login.logout.called
 
 
 def test_login_user_consent_failure(mock_login, logged_out):

--- a/tests/unit/test_cli_auth.py
+++ b/tests/unit/test_cli_auth.py
@@ -1,0 +1,33 @@
+from click.testing import CliRunner
+from cfde_submit.main import cli
+import fair_research_login.exc
+
+
+def test_login(mock_login, logged_out):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['login'])
+    assert result.exit_code == 0
+    assert mock_login.login.called
+
+
+def test_login_when_logged_in(mock_login, logged_out):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['login'])
+    assert result.exit_code == 0
+    assert mock_login.login.called
+
+
+def test_logout(mock_login, logged_in):
+    runner = CliRunner()
+    result = runner.invoke(cli, ['logout'])
+    assert result.exit_code == 0
+    assert mock_login.logout.called
+
+
+def test_login_user_consent_failure(mock_login, logged_out):
+    mock_login.login.side_effect = fair_research_login.exc.AuthFailure('Consent Denied')
+    runner = CliRunner()
+    result = runner.invoke(cli, ['login'])
+    assert result.exit_code == 0
+    assert mock_login.login.called
+    assert 'Consent Denied' in result.stdout


### PR DESCRIPTION
This fixes some inconsistencies in login behavior when using `run` vs `status`. Now, it's all the same underlying logic with `login` just double checking if a user is already logged in.

Additionally, added the pytest-cov package to test-requirements. `coverage report -m` can now be run, which shows a little over half coverage for the main client.py module:
```
Name                          Stmts   Miss  Cover   Missing
-----------------------------------------------------------
cfde_submit/__init__.py           2      0   100%
cfde_submit/client.py           250    109    56%   55, 73, 84, 143-164, 168-180, 188-190, 194, 197-198, 207-209, 291, 295-299, 312, 324, 326, 353, 359, 362-372, 378, 403-497
cfde_submit/config.py             4      0   100%
cfde_submit/exc.py               14      0   100%
cfde_submit/globus_http.py       19     15    21%   21-45
cfde_submit/main.py             164    105    36%   40-140, 151-181, 193, 214, 227
cfde_submit/validation.py        89     78    12%   32-99, 134-218
cfde_submit/version.py            1      0   100%
tests/unit/__init__.py            4      0   100%
tests/unit/conftest.py           63      0   100%
tests/unit/test_cli.py            8      0   100%
tests/unit/test_cli_auth.py      25      0   100%
tests/unit/test_client.py        64      0   100%
-----------------------------------------------------------
TOTAL                           707    307    57%
```