### PR TITLE
Various fixes for issues discovered in testing

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,6 +75,9 @@ Use them as follows:
 
 - ``cfde-submit logout`` will log you out and revoke any valid cached tokens.
 
+- ``cfde-submit version`` will output the cfde-submit version number and exit.
+
+- ``cfde-submit reset`` will reset your cfde-submit configuration.
 
 Python API
 ----------

--- a/cfde_submit/client.py
+++ b/cfde_submit/client.py
@@ -1,20 +1,19 @@
-import json
-import os
-import logging.config
-from packaging.version import parse as parse_version
 import fair_research_login
 import globus_automate_client
 import globus_sdk
+import json
+import logging.config
+import os
 import requests
 
-from cfde_submit import CONFIG, exc, globus_http, validation
 from .version import __version__ as VERSION
+from cfde_submit import CONFIG, exc, globus_http, validation
+from packaging.version import parse as parse_version
 
-logging.config.dictConfig(CONFIG["LOGGING"])
 logger = logging.getLogger(__name__)
 
 
-class CfdeClient():
+class CfdeClient:
     """The CfdeClient enables easily using the CFDE tools to ingest data."""
     client_id = "417301b1-5101-456a-8a27-423e71a2ae26"
     config_filename = os.path.expanduser("~/.cfde-submit.cfg")
@@ -294,8 +293,7 @@ class CfdeClient():
         BDBag API (see https://github.com/fair-research/bdbag for details).
         """
         self.check()
-        if verbose:
-            print("Startup: Validating input")
+        logger.debug("Startup: Validating input")
 
         catalogs = self.remote_config['CATALOGS']
         if catalog_id in catalogs.keys():
@@ -356,14 +354,12 @@ class CfdeClient():
                 "data_url": data_url,
             })
 
-        if verbose:
-            print("Flow input populated:\n{}".format(json.dumps(flow_input, indent=4,
-                                                                sort_keys=True)))
+        logger.debug("Flow input populated:\n{}".format(json.dumps(flow_input, indent=4,
+                                                                   sort_keys=True)))
         # Get Flow scope
         flow_id = flow_info["flow_id"]
         # Start Flow
-        if verbose:
-            print("Starting Flow - Submitting data")
+        logger.debug("Starting Flow - Submitting data")
         try:
             flow_res = self.flow_client.run_flow(flow_id, self.flow_scope, flow_input)
         except globus_sdk.GlobusAPIError as e:
@@ -381,8 +377,7 @@ class CfdeClient():
             "flow_id": flow_id,
             "flow_instance_id": flow_res["action_id"]
         }
-        if verbose:
-            print("Flow started successfully.")
+        logger.debug("Flow started successfully.")
 
         return {
             "success": True,

--- a/cfde_submit/config.py
+++ b/cfde_submit/config.py
@@ -10,6 +10,7 @@ EX: export CFDE_SUBMIT_LOGGING=DEBUG
 import os
 import globus_automate_client
 
+log_level = os.getenv("CFDE_SUBMIT_LOGGING") or "NOTSET"
 
 CONFIG = {
     # Files with dynamic config information in JSON
@@ -35,14 +36,17 @@ CONFIG = {
         },
         "handlers": {
             "console": {
-                "class": ("logging.StreamHandler" if os.getenv("CFDE_SUBMIT_LOGGING")
-                          else "logging.NullHandler"),
-                "level": os.getenv("CFDE_SUBMIT_LOGGING") or "INFO",
+                "class": "logging.StreamHandler",
                 "formatter": "basic",
+                "level": "NOTSET"
             }
         },
         "loggers": {
-            "cfde_submit": {"level": "DEBUG", "handlers": ["console"]},
+            'cfde_submit': {
+                "propagate": False,
+                "level": "NOTSET",
+                "handlers": ["console"],
+            },
         },
     },
     # This scope lists the GCS server for PROD that holds config data. It MAY be different

--- a/cfde_submit/main.py
+++ b/cfde_submit/main.py
@@ -2,6 +2,7 @@ import click
 import json
 import logging.config
 import os
+import sys
 
 from cfde_submit import CfdeClient, CONFIG, exc, version
 
@@ -93,7 +94,7 @@ def run(data_path, dcc_id, catalog, schema, output_dir, delete_dir, ignore_git,
         cfde = CfdeClient()
         login_user()
         logger.debug("CfdeClient initialized, starting Flow")
-        resp = yes_or_no(f'Submit datapackage {os.path.basename(data_path)} using {dcc_id}?')
+        resp = yes_or_no(f"Submit datapackage '{os.path.basename(data_path)}' using {dcc_id}?")
         if resp:
             start_res = cfde.start_deriva_flow(data_path, dcc_id=dcc_id, catalog_id=catalog,
                                                schema=schema,
@@ -216,7 +217,19 @@ def logout():
 
 @cli.command(name='version')
 def version_cmd():
+    """ Output version information and exit """
     click.secho(version.__version__)
+
+
+@cli.command()
+def reset():
+    """ Reset cfde-submit configuration """
+    remove = yes_or_no("Would you like to reset your cfde-submit settings and submit history?")
+    if remove:
+        if os.path.exists(DEFAULT_STATE_FILE):
+            os.remove(DEFAULT_STATE_FILE)
+        else:
+            sys.exit("No cfde-submit settings exist, skipping")
 
 
 def set_log_level(level):

--- a/cfde_submit/main.py
+++ b/cfde_submit/main.py
@@ -1,13 +1,12 @@
-import json
-import os
-import logging
-
 import click
+import json
+import logging.config
+import os
 
-from cfde_submit import CfdeClient, exc, version
+from cfde_submit import CfdeClient, CONFIG, exc, version
 
-logger = logging.getLogger(__name__)
 DEFAULT_STATE_FILE = os.path.expanduser("~/.cfde_client.json")
+logger = logging.getLogger(__name__)
 
 
 @click.group()
@@ -25,29 +24,34 @@ def cli():
 @click.option("--delete-dir/--keep-dir", is_flag=True, default=False, show_default=True)
 @click.option("--ignore-git/--handle-git", is_flag=True, default=False, show_default=True)
 @click.option("--dry-run", is_flag=True, default=False, show_default=True)
-@click.option("--test-submission", "--test-sub", "--test-drive", is_flag=True,
-              default=False, show_default=True)
+@click.option("--test-submission", "--test-sub", "--test-drive", is_flag=True, default=False,
+              show_default=True)
 @click.option("--verbose", "-v", is_flag=True, default=False, show_default=True)
-@click.option("--server", default=None)  # , hidden=True)
-@click.option("--force-http", is_flag=True, default=False)  # , hidden=True)
-@click.option("--bag-kwargs-file", type=click.Path(exists=True), default=None)  # , hidden=True)
-@click.option("--client-state-file", type=click.Path(exists=True), default=None)  # , hidden=True)
+@click.option("--server", default=None)
+@click.option("--force-http", is_flag=True, default=False)
+@click.option("--bag-kwargs-file", type=click.Path(exists=True), default=None)
+@click.option("--client-state-file", type=click.Path(exists=True), default=None)
 def run(data_path, dcc_id, catalog, schema, output_dir, delete_dir, ignore_git,
         dry_run, test_submission, verbose, server, force_http,
         bag_kwargs_file, client_state_file):
     """Start the Globus Automate Flow to ingest CFDE data into DERIVA."""
-    # Get any saved parameters
+
+    if verbose:
+        set_log_level("DEBUG")
+    else:
+        log_level = os.environ.get("CFDE_SUBMIT_LOGGING")
+        if log_level:
+            set_log_level(log_level)
+
     if not client_state_file:
         client_state_file = DEFAULT_STATE_FILE
     try:
         with open(client_state_file) as f:
             state = json.load(f)
-        if verbose:
-            print("Loaded previous state")
+        logger.debug("Loaded previous state")
     except FileNotFoundError:
         state = {}
-        if verbose:
-            print("No previous state found")
+        logger.debug("No previous state found")
 
     # Read bag_kwargs_file if provided
     if bag_kwargs_file:
@@ -57,16 +61,14 @@ def run(data_path, dcc_id, catalog, schema, output_dir, delete_dir, ignore_git,
         bag_kwargs = {}
 
     # Determine DCC ID to use
-    if verbose:
-        print("Determining DCC")
+    logger.debug("Determining DCC")
     # If user supplies DCC as option, will always use that
     # If supplied DCC is different from previously saved DCC, prompt to save,
     #   unless user has not saved DCC or disabled the save prompt
     state_dcc = state.get("dcc_id")
     never_save = state.get("never_save")
     if not never_save and dcc_id is not None and state_dcc is not None and state_dcc != dcc_id:
-        if verbose:
-            print("Saved DCC '{}' mismatch with provided DCC '{}'".format(state_dcc, dcc_id))
+        logger.debug("Saved DCC '{}' mismatch with provided DCC '{}'".format(state_dcc, dcc_id))
         save_dcc = (input("Would you like to save '{}' as your default DCC ID ("
                           "instead of '{}')? y/n: ".format(dcc_id, state_dcc))
                     .strip().lower() in ["y", "yes"])
@@ -79,8 +81,7 @@ def run(data_path, dcc_id, catalog, schema, output_dir, delete_dir, ignore_git,
         save_dcc = False
         print("Using saved DCC '{}'".format(dcc_id))
     elif dcc_id is None and state_dcc is None:
-        if verbose:
-            print("No saved DCC ID found and no DCC provided")
+        logger.debug("No saved DCC ID found and no DCC provided")
         dcc_id = input("Please enter the CFDE identifier for your "
                        "Data Coordinating Center: ").strip()
         save_dcc = input("Thank you. Would you like to save '{}' for future submissions? "
@@ -88,17 +89,13 @@ def run(data_path, dcc_id, catalog, schema, output_dir, delete_dir, ignore_git,
         # Save DCC ID in state if requested
         if save_dcc:
             state["dcc_id"] = dcc_id
-            if verbose:
-                print("DCC ID '{}' will be saved if the Flow initialization is successful "
-                      "and this is not a dry run"
-                      .format(dcc_id))
+            logger.debug("DCC ID '{}' will be saved if the Flow initialization is successful and "
+                         "this is not a dry run".format(dcc_id))
     try:
-        if verbose:
-            print("Initializing Flow")
+        logger.debug("Initializing Flow")
         cfde = CfdeClient()
         login_user()
-        if verbose:
-            print("CfdeClient initialized, starting Flow")
+        logger.debug("CfdeClient initialized, starting Flow")
         resp = input(f"Submit datapackage {os.path.basename(data_path)} using {dcc_id}? (y/N)? > ")
         if resp in ["y", "yes", "Y", "Yes", "aye", "yarr"]:
             start_res = cfde.start_deriva_flow(data_path, dcc_id=dcc_id, catalog_id=catalog,
@@ -131,15 +128,14 @@ def run(data_path, dcc_id, catalog, schema, output_dir, delete_dir, ignore_git,
                 state["globus_web_link"] = start_res["globus_web_link"]
                 with open(client_state_file, 'w') as out:
                     json.dump(state, out)
-                if verbose:
-                    print("State saved to '{}'".format(client_state_file))
+                logger.debug("State saved to '{}'".format(client_state_file))
 
 
 @cli.command()
 @click.option("--flow-id", default=None, show_default=True)
 @click.option("--flow-instance-id", default=None, show_default=True)
 @click.option("--raw", is_flag=True, default=False)
-@click.option("--client-state-file", type=click.Path(exists=True), default=None)  # , hidden=True)
+@click.option("--client-state-file", type=click.Path(exists=True), default=None)
 def status(flow_id, flow_instance_id, raw, client_state_file):
     """Check the status of a Flow."""
     login_user()
@@ -224,3 +220,12 @@ def logout():
 @cli.command(name='version')
 def version_cmd():
     click.secho(version.__version__)
+
+
+def set_log_level(level):
+    log_config = CONFIG["LOGGING"].copy()
+    log_config["handlers"]["console"]["level"] = level
+    log_config["loggers"]["cfde_submit"]["level"] = level
+    logging.config.dictConfig(log_config)
+    global logger
+    logger = logging.getLogger(__name__)


### PR DESCRIPTION
This fixes a few issues related to logging. This should, by default, not print any debugging information like the current release is doing. The -v flag is now the equivalent of setting CFDE_SUBMIT_LOGGING=debug.

Fixes an issue that was created due to inconsistent yes no prompts. Uses one function do to this now instead of prompting and checking multiple times throughout the code.

Added a cfde-submit reset command that resets the configuration. This can be useful in some cases. For example, when a user sets a default dcc. They can change that dcc by using --dcc-id and answering the prompts, but as far as I can tell they can't go back to not having a default.