### PR TITLE
Fixing website navigation

### DIFF
--- a/.pages
+++ b/.pages
@@ -1,0 +1,1 @@
+hide: true

--- a/cfde_submit/.pages
+++ b/cfde_submit/.pages
@@ -1,0 +1,1 @@
+hide: true

--- a/tests/unit/.pages
+++ b/tests/unit/.pages
@@ -1,0 +1,1 @@
+hide: true


### PR DESCRIPTION
Replacing https://github.com/nih-cfde/cfde-submit/pull/37 with the same changes. I think it's cause this repo is a fork, but that PR had a bunch of other changes rolled into it that shouldn't have been there. This just changes the navigation by adding 3 `.pages` files that tell the website not to render the python code and other non-docs.