### PR TITLE
rename tab

### DIFF
--- a/.pages
+++ b/.pages
@@ -1,3 +1,3 @@
 title: "Submission Tool"
 nav:
-    - docs
+    - Submission Tool: docs


### PR DESCRIPTION
got rid of setup.py in the render but now the title part isn't working, rendered as 'Docs'. try renaming the nav section so it says 'Submission Tool'

![image](https://user-images.githubusercontent.com/5659802/113348880-08a68500-92ec-11eb-8fb3-24477a2ae92b.png)
